### PR TITLE
Better receive logic and error codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ In summary, the `signature` parameter must be formatted as follows:
 
 ### 1. Receiving an existing fid
 
-A FarcasterDelegator contract is only useful when it owns an fid. In order to receive an existing fid, a FarcasterDelegator contract must be able to produce a signature authorizing receipt, as required by the Farcaster protocol. 
+A FarcasterDelegator contract is only useful when it owns an fid. In order to receive an existing fid, a FarcasterDelegator contract must be able to produce a signature authorizing receipt, as required by the Farcaster protocol.
 
 There are two way to have FarcasterDelegator produce a transfer-approval signature, both triggered by a valid signer: a) the valid signer can "prepare" the FarcasterDelegator to receive the fid, or b) the valid signer can produce a valid `TRANSFER_TYPEHASH`-related ECDSA signature.
 
@@ -109,7 +109,7 @@ A valid signer generates the EIP-712 typed data associated with the `IdRegistry.
 > [!NOTE]
 > Farcaster clients or other apps can help users prepare the typed data and signature. It's likely that this will be the most common way FarcasterDelegator contracts are used.
 
-Then, the owner of the fid can call `IdRegistry.transfer()`, passing in the address of the FarcasterDelegator contract (`to`), a `deadline`, and a signature blob (`sig`) as arguments. 
+Then, the owner of the fid can call `IdRegistry.transfer()`, passing in the address of the FarcasterDelegator contract (`to`), a `deadline`, and a signature blob (`sig`) as arguments.
 
 Since `to` is a contract, the IdRegistry will attempt to verify the signature via EIP-1271, which will result in a call to `FarcasterDelegator.isValidSignature()`. As described [above](#valid-signatures), that function will extract the typehash from the `sig`.
 

--- a/script/HatsFarcasterDelegator.s.sol
+++ b/script/HatsFarcasterDelegator.s.sol
@@ -11,7 +11,7 @@ contract DeployImplementation is Script {
 
   // default values
   bool internal _verbose = true;
-  string internal _version = "0.1.0"; // increment this with each new deployment
+  string internal _version = "0.2.0"; // increment this with each new deployment
 
   /// @dev Override default values, if desired
   function prepare(bool verbose, string memory version) public {

--- a/script/HatsFarcasterDelegator.s.sol
+++ b/script/HatsFarcasterDelegator.s.sol
@@ -49,11 +49,15 @@ contract DeployImplementation is Script {
 
     _log("");
   }
+
+  /*
+  forge script script/HatsFarcasterDelegator.s.sol:DeployImplementation -f optimism --broadcast --verify
+  */
 }
 
 contract DeployInstance is Script {
   HatsModuleFactory public constant FACTORY = HatsModuleFactory(0xfE661c01891172046feE16D3a57c3Cf456729efA);
-  address public implementation = 0x7E3c2179BF9AF88F76d03976fF9fb103208C4c3f;
+  address public implementation = 0xa947334C33daDca4BcBb396395eCFD66601BB38c;
   address public instance;
 
   // default values
@@ -123,13 +127,13 @@ contract DeployInstance is Script {
 /* FORGE CLI COMMANDS
 
 ## A. Simulate the deployment locally
-forge script script/HatsFarcasterDelegator.s.sol -f mainnet
+forge script script/HatsFarcasterDelegator.s.sol:DeployInstance -f optimism --broadcast --verify
 
 ## B. Deploy to real network and verify on etherscan
-forge script script/Deploy.s.sol -f mainnet --broadcast --verify
+forge script script/Deploy.s.sol -f optimism --broadcast --verify
 
 ## C. Fix verification issues (replace values in curly braces with the actual values)
-forge verify-contract --chain-id 1 --num-of-optimizations 1000000 --watch --constructor-args $(cast abi-encode \
+forge verify-contract --chain-id 10 --num-of-optimizations 1000000 --watch --constructor-args $(cast abi-encode \
  "constructor({args})" "{arg1}" "{arg2}" "{argN}" ) \ 
  --compiler-version v0.8.19 {deploymentAddress} \
  src/{Counter}.sol:{Counter} --etherscan-api-key $ETHERSCAN_KEY

--- a/src/HatsFarcasterDelegator.sol
+++ b/src/HatsFarcasterDelegator.sol
@@ -7,15 +7,6 @@ import {
   FarcasterDelegator, IERC1271, IIdGateway, IIdRegistry, IKeyGateway, IKeyRegistry
 } from "./FarcasterDelegator.sol";
 
-/*
-Design considerations/questions:
-- How can this contract receive fid transfers?
-- Should we support contract signatures? This might be relevant as account abstraction proliferates.
-- Should we support multiple hats? This would require a different approach to {isValidSignature}, such as potentially
-requiring that the hatId be appended to the signature. And also require logic to approve additional hats.
-- Are there any relevant Farcaster functions we should wrap to enable the {recovery} address to call them?
-*/
-
 /**
  * @title HatsFarcasterDelegator
  * @author spengrah

--- a/test/Base.t.sol
+++ b/test/Base.t.sol
@@ -29,6 +29,9 @@ contract Base is Test {
   // FarcasterDelegator errors
   error Unauthorized();
   error AlreadyRegistered();
+  error InvalidTypehash();
+  error InvalidTypedData();
+  error InvalidSigner();
 
   // FarcasterDelegator events
   event ReadyToReceive(uint256 fid);
@@ -64,6 +67,28 @@ contract Base is Test {
     vm.prank(_caller);
     // register with no extra storage
     (_fid,) = FarcasterDelegator(payable(_farcasterDelegator)).register{ value: 1 ether }(_recovery, 0);
+  }
+
+  /*//////////////////////////////////////////////////////////////
+                            INVALID TYPEHASH
+  //////////////////////////////////////////////////////////////*/
+
+  function _signInvalidTypehash(uint256 _pk) internal returns (bytes32 digest, bytes memory _signature) {
+    // build a ~random digest
+    digest = keccak256(abi.encodePacked("~random digest"));
+
+    // build a ~random typhash
+    bytes32 typehash = keccak256(abi.encodePacked("~random typehash"));
+
+    // sign it to generate the preliminary signature
+    (uint8 v, bytes32 r, bytes32 s) = vm.sign(_pk, digest);
+    _signature = abi.encodePacked(r, s, v);
+
+    // assert that the preliminary signature is the correct length
+    assertEq(_signature.length, 65);
+
+    // append the typehash to the signature
+    _signature = abi.encodePacked(_signature, typehash);
   }
 
   /*//////////////////////////////////////////////////////////////


### PR DESCRIPTION
This PR makes two primary improvements:

1. Better logic for how the contract can receive an existing fid. It is now clearer that there are two paths: 

  - a) Approving an fid upfront via `prepareToReceive()`. This is useful when the authorized signer(s) for the TRANSFER_TYPEHASH cannot conveniently produce a cryptographic signature for inclusion in a `IdRegistry.transfer` call. For example, if the the authorized signer is a contract and therefore cannot produce a cryptographic signature, or if it is an EOA that is unlikely to interact with a farcaster client that supports the other path.

  - b) Producing a valid cryptographic signature of TRANSFER_TYPEHASH-typed data, just like for other actions/typehashes

  - Supporting this change also led to more efficient logic and therefore lower gast costs for `isValidSignature`.

2. More precise error codes returned by `isValidSignature` to facilitate better testing and troubleshooting